### PR TITLE
Pass `-irix-symtab` to as

### DIFF
--- a/gcc.c
+++ b/gcc.c
@@ -628,7 +628,7 @@ static struct compiler default_compilers[] =
 		   %{aux-info*}\
 		   %{pg:%{fomit-frame-pointer:%e-pg and -fomit-frame-pointer are incompatible}}\
 		   %{S:%W{o*}%{!o*:-o %b.s}}%{!S:-o %{|!pipe:%g.s}} |\n\
-              %{!S:as %a %Y %{mabi*}\
+              %{!S:as %a %Y %{mabi*} %{irix-symtab}\
 		      %{c:%W{o*}%{!o*:-o %w%b%O}}%{!c:-o %d%w%u%O}\
                       %{!pipe:%g.s} %A\n }}}}"},
   {"-",
@@ -663,7 +663,7 @@ static struct compiler default_compilers[] =
 		   %{aux-info*}\
 		   %{pg:%{fomit-frame-pointer:%e-pg and -fomit-frame-pointer are incompatible}}\
 		   %{S:%W{o*}%{!o*:-o %b.s}}%{!S:-o %{|!pipe:%g.s}} |\n\
-              %{!S:as %a %Y %{mabi*}\
+              %{!S:as %a %Y %{mabi*} %{irix-symtab}\
 		      %{c:%W{o*}%{!o*:-o %w%b%O}}%{!c:-o %d%w%u%O}\
                       %{!pipe:%g.s} %A\n }}}}"},
   {".h", "@c-header"},
@@ -687,12 +687,12 @@ static struct compiler default_compilers[] =
 			%{aux-info*}\
 			%{pg:%{fomit-frame-pointer:%e-pg and -fomit-frame-pointer are incompatible}}\
 			%{S:%W{o*}%{!o*:-o %b.s}}%{!S:-o %{|!pipe:%g.s}} |\n\
-		     %{!S:as %a %Y %{mabi*}\
+		     %{!S:as %a %Y %{mabi*} %{irix-symtab}\
 			     %{c:%W{o*}%{!o*:-o %w%b%O}}%{!c:-o %d%w%u%O}\
 			     %{!pipe:%g.s} %A\n }}}}"},
   {".s", "@assembler"},
   {"@assembler",
-   "%{!M:%{!MM:%{!E:%{!S:as %a %Y %{mabi*}\
+   "%{!M:%{!MM:%{!E:%{!S:as %a %Y %{mabi*} %{irix-symtab}\
 		            %{c:%W{o*}%{!o*:-o %w%b%O}}%{!c:-o %d%w%u%O}\
 			    %i %A\n }}}}"},
   {".S", "@assembler-with-cpp"},
@@ -705,7 +705,7 @@ static struct compiler default_compilers[] =
         %{traditional-cpp:-traditional}\
 	%{g*} %{W*} %{w} %{pedantic*} %{H} %{d*} %C %{D*} %{U*} %{i*} %Z\
         %i %{!M:%{!MM:%{!E:%{!pipe:%g.s}}}}%{E:%W{o*}}%{M:%W{o*}}%{MM:%W{o*}} |\n",
-   "%{!M:%{!MM:%{!E:%{!S:as %a %Y %{mabi*}\
+   "%{!M:%{!MM:%{!E:%{!S:as %a %Y %{mabi*} %{irix-symtab}\
                     %{c:%W{o*}%{!o*:-o %w%b%O}}%{!c:-o %d%w%u%O}\
 		    %{!pipe:%g.s} %A\n }}}}"},
 #include "specs.h"


### PR DESCRIPTION
Add `-irix-symtab` support to gcc, which passes it directly to gas.

Allowing to instead of invoking gcc like this
```
gcc file.c -Wa,-irix-symtab
```
to invoke it like this
```
gcc file.c -irix-symtab
```
Producing the same results