### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,36 +31,41 @@ jobs:
         if: matrix.TARGET.OS == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential bison file gperf gcc gcc-multilib
+          sudo apt-get install -y build-essential bison file gperf gcc gcc-multilib autoconf
+
       - name: Configure for mips
         shell: bash
         run: |
           ./configure --target=mips-mips-gnu --prefix=/opt/cross --with-gnu-as --disable-gprof --disable-gdb --disable-werror --host=${{ matrix.TARGET.HOST }} --build=${{ matrix.TARGET.HOST }}
+
       - name: Make
         shell: bash # The generated `c-parse.c` is already commited on the repo, so we touch it to avoid regenerating it (trying to build old lex/yacc files with modern tools fails)
         run: |
           touch c-parse.c
-          make cpp cc1 xgcc cc1plus g++ CFLAGS="${{ matrix.TARGET.CFLAGS }}"
+          make CFLAGS="${{ matrix.TARGET.CFLAGS }}" xgcc cc1 cc1plus cpp cccp g++
+
       - name: Test for file
         shell: bash
         run: |
           test -f cc1
           file cc1
           ./cc1 test.c
+
       - name: Create release archive
         shell: bash
         run: |
           cp xgcc gcc
-          tar -czf ${{ matrix.TARGET.ARCHIVE_NAME }} cpp cc1 gcc cc1plus g++
+          tar -czf ${{ matrix.TARGET.ARCHIVE_NAME }} gcc cc1 cc1plus cpp cccp g++
+
       - name: Upload archive
         uses: actions/upload-artifact@v3
         with:
-          name: binutils-2.7.2-${{ matrix.TARGET.OS }}
+          name: gcc-2.7.2-${{ matrix.TARGET.OS }}
           path: |
             ${{ matrix.TARGET.ARCHIVE_NAME }}
-      - name: Update release
-        uses: johnwbyrd/update-release@v1.0.0
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           files: ${{ matrix.TARGET.ARCHIVE_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
     name: Building binutils for ${{ matrix.TARGET.OS }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install dependencies (Ubuntu)
         shell: bash
@@ -53,7 +53,7 @@ jobs:
           cp xgcc gcc
           tar -czf ${{ matrix.TARGET.ARCHIVE_NAME }} cpp cc1 gcc cc1plus g++
       - name: Upload archive
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: binutils-2.7.2-${{ matrix.TARGET.OS }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
               ARCHIVE_NAME: 'gcc-2.7.2-mac.tar.gz'
             }
 
-    name: Building binutils for ${{ matrix.TARGET.OS }}
+    name: Building gcc for ${{ matrix.TARGET.OS }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,9 @@ jobs:
         run: |
           ./configure --target=mips-mips-gnu --prefix=/opt/cross --with-gnu-as --disable-gprof --disable-gdb --disable-werror --host=${{ matrix.TARGET.HOST }} --build=${{ matrix.TARGET.HOST }}
       - name: Make
-        shell: bash
+        shell: bash # The generated `c-parse.c` is already commited on the repo, so we touch it to avoid regenerating it (trying to build old lex/yacc files with modern tools fails)
         run: |
+          touch c-parse.c
           make cpp cc1 xgcc cc1plus g++ CFLAGS="${{ matrix.TARGET.CFLAGS }}"
       - name: Test for file
         shell: bash

--- a/gcc.c
+++ b/gcc.c
@@ -4731,26 +4731,14 @@ static void
 pfatal_with_name (name)
      char *name;
 {
-  char *s;
-
-  if (errno < sys_nerr)
-    s = concat ("%s: ", my_strerror( errno ));
-  else
-    s = "cannot open `%s'";
-  fatal (s, name);
+  fatal ("%s: %s", name, my_strerror (errno));
 }
 
 static void
 perror_with_name (name)
      char *name;
 {
-  char *s;
-
-  if (errno < sys_nerr)
-    s = concat ("%s: ", my_strerror( errno ));
-  else
-    s = "cannot open `%s'";
-  error (s, name);
+  error ("%s: %s", name, my_strerror (errno));
 }
 
 static void
@@ -4759,11 +4747,7 @@ perror_exec (name)
 {
   char *s;
 
-  if (errno < sys_nerr)
-    s = concat ("installation problem, cannot exec `%s': ",
-		my_strerror (errno));
-  else
-    s = "installation problem, cannot exec `%s'";
+  s = concat ("installation problem, cannot exec `%s': ", my_strerror (errno));
   error (s, name);
 }
 

--- a/gcc.c
+++ b/gcc.c
@@ -1020,28 +1020,6 @@ translate_options (argcp, argvp)
   *argcp = newindex;
 }
 
-char *
-my_strerror(e)
-     int e;
-{
-
-#ifdef HAVE_STRERROR
-  return strerror(e);
-
-#else
-
-  static char buffer[30];
-  if (!e)
-    return "";
-
-  if (e > 0 && e < sys_nerr)
-    return sys_errlist[e];
-
-  sprintf (buffer, "Unknown error %d", e);
-  return buffer;
-#endif
-}
-
 /* Read compilation specs from a file named FILENAME,
    replacing the default ones.
 
@@ -4731,14 +4709,14 @@ static void
 pfatal_with_name (name)
      char *name;
 {
-  fatal ("%s: %s", name, my_strerror (errno));
+  fatal ("%s: %s", name, strerror (errno));
 }
 
 static void
 perror_with_name (name)
      char *name;
 {
-  error ("%s: %s", name, my_strerror (errno));
+  error ("%s: %s", name, strerror (errno));
 }
 
 static void
@@ -4747,7 +4725,7 @@ perror_exec (name)
 {
   char *s;
 
-  s = concat ("installation problem, cannot exec `%s': ", my_strerror (errno));
+  s = concat ("installation problem, cannot exec `%s': ", strerror (errno));
   error (s, name);
 }
 


### PR DESCRIPTION
- Touches `c-parse.c` to avoid regenerating it, since we are not installing old lex/yacc during the CI build 
- Changes the ci to also build on PRs
- Updates some outdated actions
  - `actions/checkout@v2` -> `actions/checkout@v4`
  - `actions/upload-artifact@v2` -> `actions/upload-artifact@v3`
- Changes the release step to a manual one